### PR TITLE
Feature/add slider to homepage

### DIFF
--- a/src/components/carousel.js
+++ b/src/components/carousel.js
@@ -1,15 +1,19 @@
 // @flow
 import React from 'react';
-// import styled from '@emotion/styled';
+import styled from '@emotion/styled';
 import ReactImagesCarousel from 'react-images';
 import type { Node } from 'react';
-
 import { Container } from 'components/contentBlocks.js';
-
 import concrete910 from '../../img/concrete-910.png';
 import concreteBauer from '../../img/concrete-bauer.png';
 import concreteOGR from '../../img/concrete-ogr.png';
 import concreteProphet from '../../img/concrete-prophet.png';
+
+const CarouselContainer = styled(Container)`
+  .react-images__footer__count {
+    font-family: 'Montserrat', serif;
+  }
+`;
 
 const images = [
   { src: concrete910 },
@@ -20,8 +24,8 @@ const images = [
 
 export default function Carousel(): Node {
   return (
-    <Container>
+    <CarouselContainer>
       <ReactImagesCarousel views={images} />
-    </Container>
+    </CarouselContainer>
   );
 }

--- a/src/components/carousel.js
+++ b/src/components/carousel.js
@@ -1,24 +1,27 @@
 // @flow
 import React from 'react';
 // import styled from '@emotion/styled';
-import { LazyLoadImage } from 'react-lazy-load-image-component';
-
+import ReactImagesCarousel from 'react-images';
 import type { Node } from 'react';
 
 import { Container } from 'components/contentBlocks.js';
 
 import concrete910 from '../../img/concrete-910.png';
-// import concreteBauer from '../../img/concrete-bauer.png';
-// import concreteOGR from '../../img/concrete-ogr.png';
-// import concreteProphet from '../../img/concrete-prophet.png';
+import concreteBauer from '../../img/concrete-bauer.png';
+import concreteOGR from '../../img/concrete-ogr.png';
+import concreteProphet from '../../img/concrete-prophet.png';
+
+const images = [
+  { src: concrete910 },
+  { src: concreteBauer },
+  { src: concreteOGR },
+  { src: concreteProphet },
+];
 
 export default function Carousel(): Node {
   return (
     <Container>
-      <LazyLoadImage src={concrete910} alt="" effect="blur" />
-      {/* <LazyLoadImage src={concreteBauer} alt="" effect="blur" />
-      <LazyLoadImage src={concreteOGR} alt="" effect="blur" />
-      <LazyLoadImage src={concreteProphet} alt="" effect="blur" /> */}
+      <ReactImagesCarousel views={images} />
     </Container>
   );
 }


### PR DESCRIPTION
Adds slider from react-images, but turns off lazy loading (for now).

I still think there might be a more elegant solution that has a better experience on mobile. Also, needs more content to be added. I'm guessing the aim is to put all renders in a single slider?